### PR TITLE
Initial MassIVE-CA documentation stub pages

### DIFF
--- a/docs/massive-ca/access_data.md
+++ b/docs/massive-ca/access_data.md
@@ -1,0 +1,1 @@
+MassiVE-CA dataset access documentation coming soon

--- a/docs/massive-ca/submit_data.md
+++ b/docs/massive-ca/submit_data.md
@@ -1,0 +1,1 @@
+MassiVE-CA dataset submission documentation coming soon

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,9 @@ nav:
           - Step2 - Setup Parameters: quant/6_msgf_workflow_2_setup_parameters.md
           - Step3 - View and Download Result: quant/6_msgf_workflow_3_view_and_download_results.md
     - MassIVE-KB: massivekb.md
+    - Massive-CA:
+      - Submit Data: massive-ca/submit_data.md
+      - Access Data: massive-ca/access_data.md
     - CoronaMassKB:
       - Introduction: CoronaMassKB/0_CoronaMassKB.md
       - Share Identification Reanalysis: share_reanalyses.md


### PR DESCRIPTION
Added placeholder documentation pages for basic MassIVE-CA operations.